### PR TITLE
Add support for handling native `event`

### DIFF
--- a/src/mousetrap-config.js
+++ b/src/mousetrap-config.js
@@ -42,8 +42,8 @@ export class MousetrapConfig {
             if (keymap.hasOwnProperty(combo)) {
                 let eventName = keymap[combo];
 
-                Mousetrap.bind(combo, () => {
-                    this._callback(eventName);
+                Mousetrap.bind(combo, ($event) => {
+                    this._callback(eventName, $event);
                 });
             }
         }


### PR DESCRIPTION
This change would allow us to be able to "override" the callback and call `$event.preventDefault()`.
